### PR TITLE
Fix links in `typescript/setup.md`

### DIFF
--- a/typescript/setup.md
+++ b/typescript/setup.md
@@ -2,12 +2,12 @@
 
 ## Install Deno
 via brew with `brew install deno`.
-Or alternatives (here)[https://docs.deno.com/runtime/getting_started/installation/]
+Or alternatives [here](https://docs.deno.com/runtime/getting_started/installation/)
 
 ## Run
 Run locally with `deno run dev`
 (will also install dependencies)
 
 The server should now be running locally on port 3000, and you can execute requests using the `./rest/chat.rest` file.
-(VS Code REST Client Plugin)[https://marketplace.visualstudio.com/items?itemName=humao.rest-client]
+[VS Code REST Client Plugin](https://marketplace.visualstudio.com/items?itemName=humao.rest-client)
 


### PR DESCRIPTION
## Summary 

As I was reading through this on GitHub I noticed that the links weren't correctly implemented. 

This PR switches from the incorrect `(name)[<url>]` to `[name](<url>)`
